### PR TITLE
Include more username formats for Mastodon and Bluesky

### DIFF
--- a/src/models/europython.py
+++ b/src/models/europython.py
@@ -93,16 +93,26 @@ class EuroPythonSpeaker(BaseModel):
     @staticmethod
     def extract_mastodon_url(text: str) -> str:
         """
-        Extract the Mastodon URL from the answer, handle @username@instance format
+        Normalize Mastodon handle or URL to the format: https://<instance>/@<username>
         """
-        if not text.startswith(("https://", "http://")) and text.count("@") == 2:
-            mastodon_url = f"https://{text.split('@')[2]}/@{text.split('@')[1]}"
-        else:
-            mastodon_url = (
-                f"https://{text.removeprefix('https://').removeprefix('http://')}"
-            )
+        text = text.strip().split("?", 1)[0]
 
-        return mastodon_url.split("?")[0]
+        # Handle @username@instance or username@instance formats
+        if "@" in text and not text.startswith("http"):
+            parts = text.split("@")
+            if len(parts) == 3:  # @username@instance
+                _, username, instance = parts
+            elif len(parts) == 2:  # username@instance
+                username, instance = parts
+            else:
+                raise ValueError("Invalid Mastodon handle format")
+            return f"https://{instance}/@{username}"
+
+        # Handle full URLs
+        if text.startswith("http://"):
+            text = "https://" + text[len("http://") :]
+
+        return text
 
     @staticmethod
     def extract_linkedin_url(text: str) -> str:
@@ -126,7 +136,7 @@ class EuroPythonSpeaker(BaseModel):
         Returns a normalized BlueSky URL in the form https://bsky.app/profile/<USERNAME>.bsky.social,
         or uses the entire domain if it's custom (e.g., .dev).
         """
-        text = text.split("?", 1)[0].strip()
+        text = text.strip().split("?", 1)[0]
 
         if text.startswith("https://"):
             text = text[8:]

--- a/src/models/europython.py
+++ b/src/models/europython.py
@@ -136,6 +136,10 @@ class EuroPythonSpeaker(BaseModel):
         if text.startswith("www."):
             text = text[4:]
 
+        # Remove @ if present
+        if text.startswith("@"):
+            text = text[1:]
+
         for marker in ("bsky.app/profile/", "bsky/"):
             if marker in text:
                 text = text.split(marker, 1)[1]

--- a/src/models/europython.py
+++ b/src/models/europython.py
@@ -91,7 +91,7 @@ class EuroPythonSpeaker(BaseModel):
         return twitter_url.split("?")[0]
 
     @staticmethod
-    def extract_mastodon_url(text: str) -> str:
+    def extract_mastodon_url(text: str) -> None | str:
         """
         Normalize Mastodon handle or URL to the format: https://<instance>/@<username>
         """
@@ -105,7 +105,7 @@ class EuroPythonSpeaker(BaseModel):
             elif len(parts) == 2:  # username@instance
                 username, instance = parts
             else:
-                raise ValueError("Invalid Mastodon handle format")
+                return None
             return f"https://{instance}/@{username}"
 
         # Handle full URLs

--- a/tests/test_social_media_extractions.py
+++ b/tests/test_social_media_extractions.py
@@ -38,7 +38,9 @@ def test_extract_linkedin_url(input_string: str, result: str) -> None:
     ("input_string", "result"),
     [
         ("username", "https://bsky.app/profile/username.bsky.social"),
+        ("@username", "https://bsky.app/profile/username.bsky.social"),
         ("username.dev", "https://bsky.app/profile/username.dev"),
+        ("@username.dev", "https://bsky.app/profile/username.dev"),
         ("username.bsky.social", "https://bsky.app/profile/username.bsky.social"),
         ("bsky.app/profile/username", "https://bsky.app/profile/username.bsky.social"),
         ("bsky/username", "https://bsky.app/profile/username.bsky.social"),

--- a/tests/test_social_media_extractions.py
+++ b/tests/test_social_media_extractions.py
@@ -13,6 +13,7 @@ from src.models.europython import EuroPythonSpeaker
             "https://mastodon.social/@username",
         ),
         ("@username@mastodon.social", "https://mastodon.social/@username"),
+        ("username@mastodon.social", "https://mastodon.social/@username"),
     ],
 )
 def test_extract_mastodon_url(input_string: str, result: str) -> None:


### PR DESCRIPTION
Include more username formats for Mastodon and Bluesky.

Mastodon:
- `username@instance`


Bluesky:
- `@username`