### PR TITLE
Migrate to new Pretalx API

### DIFF
--- a/data/examples/pretalx/speakers.json
+++ b/data/examples/pretalx/speakers.json
@@ -6,7 +6,7 @@
         "submissions": [
             "A8CD3F"
         ],
-        "avatar": "https://pretalx.com/media/avatars/picture.jpg",
+        "avatar_url": "https://pretalx.com/media/avatars/picture.jpg",
         "answers": [
             {
                 "id": 272244,

--- a/data/examples/pretalx/submissions.json
+++ b/data/examples/pretalx/submissions.json
@@ -2,20 +2,8 @@
     {
         "code": "A8CD3F",
         "speakers": [
-            {
-                "code": "F3DC8A",
-                "name": "A Speaker",
-                "biography": "This is a biography of F3D speaker",
-                "avatar": "https://pretalx.com/media/avatars/picture.jpg",
-                "email": "f3dc8a@example.com"
-            },
-            {
-                "code": "ZXCVBN",
-                "name": "ZXC Speaker",
-                "biography": "This is a biography of ZXC speaker",
-                "avatar": "https://pretalx.com/media/avatars/picture.jpg",
-                "email": "zxcvbn@example.com"
-            }
+            "F3DC8A",
+            "ZXCVBN"
         ],
         "title": "This is a test talk from a test speaker about a test topic.",
         "submission_type": "Talk (long session)",
@@ -127,13 +115,7 @@
     {
         "code": "B8CD4F",
         "speakers": [
-            {
-                "code": "G3DC8A",
-                "name": "Another Speaker",
-                "biography": "This is a biography of F3D speaker",
-                "avatar": "https://pretalx.com/media/avatars/picture.jpg",
-                "email": "g3dc8a@example.com"
-            }
+            "G3DC8A"
         ],
         "title": "A talk with shorter title",
         "submission_type": "Talk",

--- a/data/examples/pretalx/submissions.json
+++ b/data/examples/pretalx/submissions.json
@@ -21,7 +21,9 @@
         "submission_type": "Talk (long session)",
         "submission_type_id": 3961,
         "track": {
-            "en": "Software Engineering & Architecture"
+            "name": {
+                "en": "Software Engineering & Architecture"
+            }
         },
         "track_id": 4493,
         "state": "confirmed",
@@ -137,7 +139,9 @@
         "submission_type": "Talk",
         "submission_type_id": 3961,
         "track": {
-            "en": "PyData: LLMs"
+            "name": {
+                "en": "PyData: LLMs"
+            }
         },
         "track_id": 4493,
         "state": "confirmed",

--- a/src/download.py
+++ b/src/download.py
@@ -25,12 +25,16 @@ headers = {
 }
 
 base_url = f"https://pretalx.com/api/events/{Config.event}/"
-schedule_url = base_url + "schedules/latest/"
+schedule_url = (
+    base_url
+    + "schedules/latest?expand="
+    + "slots,slots.submission,slots.submission.submission_type,slots.submission.track,slots.room"
+)
 
 # Build resource list dynamically based on exclusions
 resources = [
-    "submissions?state=confirmed",
-    "speakers",
+    "submissions?state=confirmed&expand=answers.question,submission_type,track,slots.room",
+    "speakers?expand=answers.question",
 ]
 
 if "youtube" not in exclude:

--- a/src/download.py
+++ b/src/download.py
@@ -29,8 +29,8 @@ schedule_url = base_url + "schedules/latest/"
 
 # Build resource list dynamically based on exclusions
 resources = [
-    "submissions?questions=all&state=confirmed",
-    "speakers?questions=all",
+    "submissions?state=confirmed",
+    "speakers",
 ]
 
 if "youtube" not in exclude:

--- a/src/download.py
+++ b/src/download.py
@@ -33,7 +33,7 @@ schedule_url = (
 
 # Build resource list dynamically based on exclusions
 resources = [
-    "submissions?state=confirmed&expand=answers.question,submission_type,track,slots.room",
+    "submissions?state=confirmed&expand=answers.question,submission_type,track,slots.room,resources",
     "speakers?expand=answers.question",
 ]
 

--- a/src/models/pretalx.py
+++ b/src/models/pretalx.py
@@ -90,6 +90,10 @@ class PretalxSubmission(BaseModel):
     @field_validator("resources", mode="before")
     @classmethod
     def handle_resources(cls, v) -> list[dict[str, str]] | None:
+        if v and all(isinstance(res, int) for res in v):
+            # currently, ?expand=resources is broken in Pretalx
+            # https://github.com/pretalx/pretalx/issues/2040
+            return None
         return v or None
 
     @model_validator(mode="before")

--- a/src/models/pretalx.py
+++ b/src/models/pretalx.py
@@ -98,8 +98,9 @@ class PretalxSubmission(BaseModel):
         values["speakers"] = sorted([s["code"] for s in values["speakers"]])
 
         # Set slot information
-        if values.get("slot"):
-            slot = PretalxSlot.model_validate(values["slot"])
+        if values.get("slots"):
+            slot = PretalxSlot.model_validate(values["slots"][0])
+            values["slot"] = slot
             values["room"] = slot.room
             values["start"] = slot.start
             values["end"] = slot.end
@@ -146,3 +147,28 @@ class PretalxSchedule(BaseModel):
 
     slots: list[PretalxSubmission]
     breaks: list[PretalxScheduleBreak]
+
+    @model_validator(mode="before")
+    @classmethod
+    def process_values(cls, values) -> dict:
+        submission_slots = []
+        break_slots = []
+        for slot_dict in values["slots"]:
+            # extract nested slot fields into slot
+            slot_object = PretalxSlot.model_validate(slot_dict)
+            slot_dict["slot"] = slot_object
+            slot_dict["room"] = slot_object.room
+            slot_dict["start"] = slot_object.start
+            slot_dict["end"] = slot_object.end
+
+            if slot_dict.get("submission") is None:
+                break_slots.append(slot_dict)
+            else:
+                # merge submission fields into slot
+                slot_dict.update(slot_dict.get("submission", {}))
+
+                submission_slots.append(slot_dict)
+
+        values["slots"] = submission_slots
+        values["breaks"] = break_slots
+        return values

--- a/src/models/pretalx.py
+++ b/src/models/pretalx.py
@@ -90,15 +90,19 @@ class PretalxSubmission(BaseModel):
     @field_validator("resources", mode="before")
     @classmethod
     def handle_resources(cls, v) -> list[dict[str, str]] | None:
-        if v and all(isinstance(res, int) for res in v):
-            # currently, ?expand=resources is broken in Pretalx
-            # https://github.com/pretalx/pretalx/issues/2040
-            return None
         return v or None
 
     @model_validator(mode="before")
     @classmethod
     def process_values(cls, values) -> dict:
+        # Transform resource information
+        if raw_resources := values.get("resources"):
+            resources = [
+                {"description": res["description"], "resource": res["resource"]}
+                for res in raw_resources
+            ]
+            values["resources"] = resources
+
         # Set slot information
         if values.get("slots"):
             slot = PretalxSlot.model_validate(values["slots"][0])
@@ -168,6 +172,9 @@ class PretalxSchedule(BaseModel):
             else:
                 # merge submission fields into slot
                 slot_dict.update(slot_dict.get("submission", {}))
+
+                # remove resource IDs (not expandable with API, not required for schedule)
+                slot_dict.pop("resources", None)
 
                 submission_slots.append(slot_dict)
 

--- a/src/models/pretalx.py
+++ b/src/models/pretalx.py
@@ -95,8 +95,6 @@ class PretalxSubmission(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def process_values(cls, values) -> dict:
-        values["speakers"] = sorted([s["code"] for s in values["speakers"]])
-
         # Set slot information
         if values.get("slots"):
             slot = PretalxSlot.model_validate(values["slots"][0])

--- a/src/models/pretalx.py
+++ b/src/models/pretalx.py
@@ -33,7 +33,7 @@ class PretalxSlot(BaseModel):
     @classmethod
     def handle_localized(cls, v) -> str | None:
         if isinstance(v, dict):
-            return v.get("en")
+            return v["name"].get("en")
         return v
 
 
@@ -77,7 +77,7 @@ class PretalxSubmission(BaseModel):
     @classmethod
     def handle_localized(cls, v) -> str | None:
         if isinstance(v, dict):
-            return v.get("en")
+            return v["name"].get("en")
         return v
 
     @field_validator("duration", mode="before")

--- a/src/models/pretalx.py
+++ b/src/models/pretalx.py
@@ -45,7 +45,7 @@ class PretalxSpeaker(BaseModel):
     code: str
     name: str
     biography: str | None = None
-    avatar: str
+    avatar_url: str
     submissions: list[str]
     answers: list[PretalxAnswer]
 

--- a/src/utils/parse.py
+++ b/src/utils/parse.py
@@ -34,12 +34,12 @@ class Parse:
             js = json.load(fd)
             all_speakers = [PretalxSpeaker.model_validate(s) for s in js]
 
-            speakers_with_publishable_sessions: list[PretalxSubmission] = []
+            speakers_with_publishable_sessions: list[PretalxSpeaker] = []
             for speaker in all_speakers:
                 if publishable_sessions := Utils.publishable_sessions_of_speaker(
                     speaker, publishable_sessions_keys
                 ):
-                    speaker.submissions = publishable_sessions
+                    speaker.submissions = sorted(publishable_sessions)
                     speakers_with_publishable_sessions.append(speaker)
 
             publishable_speakers_by_code = {

--- a/src/utils/transform.py
+++ b/src/utils/transform.py
@@ -83,7 +83,7 @@ class Transform:
                 code=speaker.code,
                 name=speaker.name,
                 biography=speaker.biography,
-                avatar=speaker.avatar,
+                avatar=speaker.avatar_url,
                 slug=speaker_code_to_slug[speaker.code],
                 answers=speaker.answers,
                 submissions=speaker.submissions,


### PR DESCRIPTION
## Summary
Pretalx updated their API and it broke our setup.
This PR fixes it, the YouTube integration was not tested (my token cannot access `/p/youtube`, so I used `make all EXCLUDE=youtube`)

Fixes #132 

## Details
### API Changes
#### Nested resources
In the old API, nested resources were always embedded in the parent response body:
```text
GET /speakers/<ID>
{
  ...
  answers: [
    {"id:" ..., "question": {...}, ...},
    ...
  ]
}
```

In the new API, nested resources are only referenced by their IDs:
```text
GET /speakers/<ID>
{
  ...
  answers: [
    123,
    ...
  ]
}
```

The old behavior can be restored with the `expand` query:
```text
GET /speakers/<ID>?expand=answers,answers.question
{
  ...
  answers: [
    {"id:" ..., "question": {...}, ...},
    ...
  ]
}
```

This PR adds `expand` queries where necessary.

### Removed query `?questions=all`
Previously, we used `?questions=all` on the `/submissions` and `speakers/` endpoints. This is not supported anymore. Answers and questions are now handled like all other nested resources (see above).

This PR removes these queries.

#### Schedule slots
Previously, the response to `/schedule` contained the keys `slots` and `breaks`:
* `slots` contained all submission slots (talks, tutorials, ...) and contained objects of type "Submission"
* `breaks` contained all non-submission slots (lunch and coffee breaks) and contained objects of another type
* Both these object types contained the key `slot` with the slot details (time, location).

Previously, the responses to `/submissions` contained one `slot` object per submission (the first slot).

In the new version, `/schedule` only returns `slots`. The response objects contain the slot details (time, location), and an optional reference to the submission.
The responses to `/submissions` now contain `slots` (all slots) instead of `slot` (first slot).

This PR uses pydantic's BeforeValidators to re-arrange the data to the old format before deserialization.

#### Changed structure of localized names
Before:
```text
GET /submissions/<ID>
{
  "track": {"en": "<NAME>"}
}
```
After:
```text
GET /submissions/<ID>
{
  "track": {"name": {"en": "<NAME>"}}
}
```

This PR updates the deserialization logic for `submission.track`, `submission.submission_type`, and `slot.room`.

#### Renamed `speaker.avatar` to `speaker.avatar_url`
This PR updates the deserialization keyword, but keeps `avatar` in the transformation result.